### PR TITLE
CSS relocation

### DIFF
--- a/Site/baking101.html
+++ b/Site/baking101.html
@@ -1,18 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-	<!-- <head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Baking 101</title>
-		<script type="text/javascript" src="js/modularity_head.js"></script>
-		<link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet">
-		<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
-		<link rel="stylesheet" href="css/style.css" />
-		
-	</head> -->
-
 	<head id="pageHeader">
 		<meta charset="UTF-8" />
+		<link rel="stylesheet" href="css/style.css">
 		<script src="./js/modularity_head.js"></script>
 		<title>Baking 101 - Bestemor Borghild</title>
 	</head>

--- a/Site/contact.html
+++ b/Site/contact.html
@@ -3,6 +3,7 @@
 
 	<head id="pageHeader">
 		<meta charset="UTF-8" />
+		<link rel="stylesheet" href="css/style.css">
 		<script src="./js/modularity_head.js"></script>
 		<title>Kontakt oss - Bestemor Borghild</title>
 	</head>

--- a/Site/content.html
+++ b/Site/content.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head id="pageHeader">
 		<meta charset="UTF-8" />
+		<link rel="stylesheet" href="css/style.css">
 		<script src="./js/modularity_head.js"></script>
 		<title>Innhold - Bestemor Borghild</title>
 		<script src="./js/title.js"></script>

--- a/Site/index.html
+++ b/Site/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 
 <head id="pageHeader">
-    <meta charset="UTF-8" />
+	<meta charset="UTF-8" />
+	<link rel="stylesheet" href="css/style.css">
     <script src="./js/modularity_head.js"></script> 
     <title>Bestemor Borghilds Bakebonanza</title>
 </head>

--- a/Site/js/modularity_head.js
+++ b/Site/js/modularity_head.js
@@ -1,4 +1,4 @@
-(function() { // Use IIFE since head element essential to load quickly. Read more: https://developer.mozilla.org/en-US/docs/Glossary/IIFE
+(function() { // Use IIFE since head element essential to load, but only required to be loaded once per site. Read more: https://developer.mozilla.org/en-US/docs/Glossary/IIFE
     // Retrieve the head element
     var head = document.getElementById("pageHeader");
     // charSet not input by script as it needs to be defined by parser, cant be changed after HTML
@@ -9,12 +9,6 @@
     viewPort.name = "viewport";
     viewPort.content = "width=device-width, initial-scale=1.0";
     head.appendChild(viewPort);
-
-    // Include the common CSS file for the website
-    var styleSheet = document.createElement("link");
-    styleSheet.rel = "stylesheet";
-    styleSheet.href = "css/style.css";
-    head.appendChild(styleSheet);
 
     // Adding some new fonts
     var fontPoppins = document.createElement("link");

--- a/Site/recipe_list.html
+++ b/Site/recipe_list.html
@@ -1,17 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-	<!-- <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script type="text/javascript" src="js/modularity_head.js"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/style.css">
-    <title>Oppskrifter</title>
-  </head> -->
-
 	<head id="pageHeader">
 		<meta charset="UTF-8" />
+		<link rel="stylesheet" href="css/style.css">
 		<script src="./js/modularity_head.js"></script>
 		<title>Oppskrifter - Bestemor Borghild</title>
 	</head>


### PR DESCRIPTION
Etter å ha spurt thea så virker det som at hun foretrekker at vi laster CSS direkte i head istedet for gjennom modularity_head.js. 
Har dermed fjernet CSS fra modularity_head.js, og lagt til i head for alle html sidene.